### PR TITLE
modified goofys driver to use environment variables for AWS keys

### DIFF
--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -55,12 +55,6 @@ func Mount(target string, options map[string]string) interface{} {
 		"--file-mode", fileMode,
 	}
 
-	if accessKey, ok := options["access-key"]; ok {
-		args = append(args, "--access-key", accessKey)
-	}
-	if secretKey, ok := options["secret-key"]; ok {
-		args = append(args, "--secret-key", secretKey)
-	}
 	if endpoint, ok := options["endpoint"]; ok {
 		args = append(args, "--endpoint", endpoint)
 	}
@@ -75,6 +69,13 @@ func Mount(target string, options map[string]string) interface{} {
 	if !isMountPoint(mountPath) {
 		os.MkdirAll(mountPath, 0755)
 		mountCmd := exec.Command("goofys", args...)
+		mountCmd.Env = os.Environ()
+		if accessKey, ok := options["access-key"]; ok {
+			mountCmd.Env = append(mountCmd.Env, fmt.Sprintf("AWS_ACCESS_KEY_ID=", accessKey))
+		}
+		if secretKey, ok := options["secret-key"]; ok {
+			mountCmd.Env = append(mountCmd.Env, fmt.Sprintf("AWS_SECRET_KEY_ID=", secretKey))
+		}
 		mountCmd.Start()
 	}
 

--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -74,7 +74,7 @@ func Mount(target string, options map[string]string) interface{} {
 			mountCmd.Env = append(mountCmd.Env, fmt.Sprintf("AWS_ACCESS_KEY_ID=", accessKey))
 		}
 		if secretKey, ok := options["secret-key"]; ok {
-			mountCmd.Env = append(mountCmd.Env, fmt.Sprintf("AWS_SECRET_KEY_ID=", secretKey))
+			mountCmd.Env = append(mountCmd.Env, fmt.Sprintf("AWS_SECRET_ACCESS_KEY=", secretKey))
 		}
 		mountCmd.Start()
 	}


### PR DESCRIPTION
Per the [Goofys documentation)[https://github.com/kahing/goofys], the AWS keys cannot be specified on the `goofys` command line, but they can be specified as environment variables. 

There's still a bug where a failure to mount the remote volume still results in success being output; this should be fixed. 