### PR TITLE
added support for UID, GID in goofys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ volumes:
         # Optional
         dirMode: "0755"
         fileMode: "0644"
+        uid: "501"
+        gid: "20"
         subPath: "key/prefix"
         endpoint: "s3.not-aws.com"
         debug_s3: false

--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -62,6 +62,12 @@ func Mount(target string, options map[string]string) interface{} {
 	if region, ok := options["region"]; ok {
 		args = append(args, "--region", region)
 	}
+	if uid, ok := options["uid"]; ok {
+		args = append(args, "--uid", uid)
+	}
+	if gid, ok := options["gid"]; ok {
+		args = append(args, "--gid", gid)
+	}
 
 	debug_s3, ok := options["debug_s3"]
 	if ok && debug_s3 == "true" {


### PR DESCRIPTION
This allows deployments to configure the UID and GID for which the owner and group of files should be set. It just passes them along to the `goofys` command line untouched. Note that this is **not** the username or group name, but the UID and GID from `/etc/passwd`. This allows the node to mount them to a UID/GID not present in `/etc/passwd` on the node, but present in the `/etc/password` of the container into which the volume is mounted. 