### PR TITLE
add selinuxRelable: false to capibilities, as fuse does not support it

### DIFF
--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -21,7 +21,8 @@ func makeResponse(status, message string) map[string]interface{} {
 func Init() interface{} {
 	resp := makeResponse("Success", "No Initialization required")
 	resp["capabilities"] = map[string]interface{}{
-		"attach": false,
+		"attach":         false,
+		"selinuxRelabel": false,
 	}
 	return resp
 }


### PR DESCRIPTION
Trying to use this flexVolume Driver on a SELINUX enabled Distro doesn't work, as fuse doesn't allow to relabel SELINUX tags on files. 

This fixes it.