### PR TITLE
Requester pays

### DIFF
--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -75,8 +75,8 @@ func Mount(target string, options map[string]string) interface{} {
 		args = append(args, "--debug_s3")
 	}
 
-	requester_pays, ok := options["requester_pays"]
-	if ok && requester_pays == "true" {
+	requesterPays, ok := options["requesterPays"]
+	if ok && requesterPays == "true" {
 		args = append(args, "--requester-pays")
 	}
 

--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -75,6 +75,11 @@ func Mount(target string, options map[string]string) interface{} {
 		args = append(args, "--debug_s3")
 	}
 
+	requester_pays, ok := options["requester_pays"]
+	if ok && requester_pays == "true" {
+		args = append(args, "--requester-pays")
+	}
+
 	mountPath := path.Join("/mnt/goofys", bucket)
 
 	args = append(args, bucket, mountPath)
@@ -83,7 +88,7 @@ func Mount(target string, options map[string]string) interface{} {
 		exec.Command("umount", mountPath).Run()
 		exec.Command("rm", "-rf", mountPath).Run()
 		os.MkdirAll(mountPath, 0755)
-		
+
 		mountCmd := exec.Command("goofys", args...)
 		mountCmd.Env = os.Environ()
 		if accessKey, ok := options["access-key"]; ok {

--- a/helm-chart/s3-fuse-flex-volume/templates/fuse_install_deps.yaml
+++ b/helm-chart/s3-fuse-flex-volume/templates/fuse_install_deps.yaml
@@ -23,7 +23,7 @@ data:
         apt-get update
         apt-get install -y fuse python3-pip git
         pip3 install git+git://github.com/met-office-lab/pysssix.git@big_cache
-        curl -L -o /usr/bin/goofys http://bit.ly/goofys-latest
+        curl -L -o /usr/bin/goofys https://github.com/kahing/goofys/releases/latest/download/goofys
         chmod +x /usr/bin/goofys
     }
 
@@ -32,7 +32,7 @@ data:
         yum update -y
         yum install -y fuse-devel fuse-libs fuse python3-pip git
         pip3 install git+git://github.com/met-office-lab/pysssix.git@big_cache
-        curl -L -o /usr/bin/goofys http://bit.ly/goofys-latest
+        curl -L -o /usr/bin/goofys https://github.com/kahing/goofys/releases/latest/download/goofys
         chmod +x /usr/bin/goofys
     }
 


### PR DESCRIPTION
We’ve been using this library with goofys, but we often use it with public datasets that are [requester pays buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html).

goofys supports this — it’s just an additional flag — but it does require updating to a more recent version. We've tested it with 0.24, whereas the existing bit.ly link points to 0.19.

I've added `requesterPays` to the goofys options, to enable that flag. Also replaced the existing bit.ly link with the official latest-release link.