### PR TITLE
feat: added support for use-content-type in goofys driver

### DIFF
--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -75,6 +75,11 @@ func Mount(target string, options map[string]string) interface{} {
 		args = append(args, "--debug_s3")
 	}
 
+	use_content_type, ok := options["use_content_typee"]
+	if ok && use_content_type == "true" {
+		args = append(args, "--use-content-type")
+	}
+
 	mountPath := path.Join("/mnt/goofys", bucket)
 
 	args = append(args, bucket, mountPath)

--- a/drivers/goofys/main.go
+++ b/drivers/goofys/main.go
@@ -75,7 +75,7 @@ func Mount(target string, options map[string]string) interface{} {
 		args = append(args, "--debug_s3")
 	}
 
-	use_content_type, ok := options["use_content_typee"]
+	use_content_type, ok := options["use_content_type"]
 	if ok && use_content_type == "true" {
 		args = append(args, "--use-content-type")
 	}


### PR DESCRIPTION
Issue with uploading files as binary/octet-stream to S3 if you do not have this option set. With it enabled it will try to figure out the correct MIME type. The option comes default with goofys.